### PR TITLE
Accept any RMW implementation, not just the default

### DIFF
--- a/rmw_implementation-extras.cmake.in
+++ b/rmw_implementation-extras.cmake.in
@@ -16,18 +16,8 @@
 
 find_package(rmw_implementation_cmake REQUIRED)
 
-if(NOT "${RMW_IMPLEMENTATION}" STREQUAL "")
-  set(requested_rmw_implementation "${RMW_IMPLEMENTATION}")
-  set(requested_rmw_implementation_from "CMake")
-elseif(NOT "$ENV{RMW_IMPLEMENTATION}" STREQUAL "")
-  set(requested_rmw_implementation "$ENV{RMW_IMPLEMENTATION}")
-  set(requested_rmw_implementation_from
-    "environment variable 'RMW_IMPLEMENTATION'")
-else()
-  set(requested_rmw_implementation "@RMW_IMPLEMENTATION@")
-  set(requested_rmw_implementation_from
-    "the default when @PROJECT_NAME@ was built")
-endif()
+get_default_rmw_implementation(requested_rmw_implementation)
+set(requested_rmw_implementation_from "get_default_rmw_implementation")
 
 if(@RMW_IMPLEMENTATION_DISABLE_RUNTIME_SELECTION@)
   message(STATUS "Using RMW implementation '@RMW_IMPLEMENTATION@'")


### PR DESCRIPTION
This CMake snippet requires consumers to have the "default" RMW implementation installed to work properly.

Due to the lack of weak or complex dependencies in the RPM version used in CentOS 7, we're given a choice between getting a "random" RMW implementation or taking an explicit dependency on a specific one, a dependency that will affect the end-user as well. That would mean that everyone would have to install the default RMW implementation even if they don't want to use it.

The `get_default_rmw_implementation` takes a similar approach to determining which RMW implementation should be used as this snippet does, except that it falls back on any available one if the default one isn't available. If we leverage that behavior here, we de-duplicate similar code, and we allow any valid RMW implementation to satisfy the requirement here.

I tested this approach on the RPM farm, and this was the only spot where it was necessary to work around the packaging system's dependency on the "default" RMW. If this patch demonstrates that this approach is valid, I'll propose this patch upstream.

**NOTE**: If this PR is squash-merged, be sure to drop the PR number from the end of the commit message, or every time this patch is re-applied by Bloom, it will be back-linked from this PR.