### PR TITLE
Resolve rmw_implementation_packages dependencies

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -20,7 +20,6 @@
   Bloom does not support group_depend so entries below duplicate the group rmw_implementation_packages.
   This ensures that binary packages have support for all of these rmw impl. enabled.
   -->
-  <build_depend>rmw_connext_cpp</build_depend>
   <build_depend>rmw_cyclonedds_cpp</build_depend>
   <build_depend>rmw_fastrtps_cpp</build_depend>
   <!-- end of group dependencies added for bloom -->

--- a/rpm/template.spec.em
+++ b/rpm/template.spec.em
@@ -15,6 +15,10 @@ License:        @(License)
 Source0:        %{name}-%{version}.tar.gz
 @[if NoArch]@\nBuildArch:      noarch@\n@[end if]@
 
+Requires:       ros-eloquent-rmw-implementation-packages(member)
+%if 0%{?with_weak_deps}
+Suggests:       ros-eloquent-rmw-cyclonedds-cpp
+%endif
 @[for p in Depends]Requires:       @p@\n@[end for]@
 @[for p in BuildDepends]BuildRequires:  @p@\n@[end for]@
 @[for p in Conflicts]Conflicts:      @p@\n@[end for]@


### PR DESCRIPTION
Debian counterpart: https://github.com/ros2-gbp/rmw_implementation-release/blob/patches/debian/eloquent/rmw_implementation/0001-Add-runtime-dependency-on-an-rmw_implementation.patch

The version of RPM in CentOS 7 lacks support for weak or complex dependency expressions. The best way we can express a dependency on "one of the RMW implementations" is to take a dependency on the virtual package that each of those RMW implementations provides because of their membership in the `rmw_implementation_packages` group.

Unfortunately, we don't have a good way to express what the "default" should be without support for weak dependencies. When no packages are installed which satisfy this requirement already, RPM seems to choose the first provider alphabetically, though I can't find any documentation to support that.

Also drop Connext, since that RMW is not supported for any RHEL distributions at this time.

**NOTE**: If this PR is squash-merged, be sure to drop the PR number from the end of the commit message, or every time this patch is re-applied by Bloom, it will be back-linked from this PR.