### PR TITLE
Fix typo in Rosdistro substitution.

### DIFF
--- a/debian/control.em
+++ b/debian/control.em
@@ -8,7 +8,7 @@ Standards-Version: 3.9.2
 
 Package: @(Package)
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends)), ros-rolling-rmw-cyclonedds-cpp | ros-rolling-rmw-connext-cpp | ros-rolling-rmw-fastrtps-cpp
+Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends)), ros-@(Rosidstro)-rmw-cyclonedds-cpp | ros-@(Rosidstro)-rmw-connextdds | ros-@(Rosidstro)-rmw-fastrtps-cpp
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@
 Description: @(Description)

--- a/debian/control.em
+++ b/debian/control.em
@@ -8,7 +8,7 @@ Standards-Version: 3.9.2
 
 Package: @(Package)
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends)), ros-@(Rosidstro)-rmw-cyclonedds-cpp | ros-@(Rosidstro)-rmw-connextdds | ros-@(Rosidstro)-rmw-fastrtps-cpp
+Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends)), ros-@(Rosdistro)-rmw-cyclonedds-cpp | ros-@(Rosdistro)-rmw-connextdds | ros-@(Rosdistro)-rmw-fastrtps-cpp
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@
 Description: @(Description)


### PR DESCRIPTION
The first commit is spurious and can be rebased out but will squash into nothingness if we let it.