### PR TITLE
Add runtime dependency on an rmw_implementation.

### DIFF
--- a/debian/control.em
+++ b/debian/control.em
@@ -8,7 +8,7 @@ Standards-Version: 3.9.2
 
 Package: @(Package)
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends))
+Depends: ${shlibs:Depends}, ${misc:Depends}, @(', '.join(Depends)), ros-@(Rosdistro)-rmw-cyclonedds-cpp | ros-@(Rosdistro)-rmw-connextdds | ros-@(Rosdistro)-rmw-fastrtps-cpp
 @[if Conflicts]Conflicts: @(', '.join(Conflicts))@\n@[end if]@
 @[if Replaces]Replaces: @(', '.join(Replaces))@\n@[end if]@
 Description: @(Description)


### PR DESCRIPTION
Restore patches dropped during Rolling migration https://github.com/ros/rosdistro/issues/32128